### PR TITLE
fix: missing & on hourly params

### DIFF
--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -43,7 +43,9 @@ String generateArgsDHCBase(
   args += dailyArgs.isNotEmpty
       ? "${args.isNotEmpty ? "&" : ""}daily=${dailyArgs.join(",")}"
       : "";
-  args += hourlyArgs.isNotEmpty ? "hourly=${hourlyArgs.join(",")}" : "";
+  args += hourlyArgs.isNotEmpty
+      ? "${args.isNotEmpty ? "&" : ""}hourly=${hourlyArgs.join(",")}"
+      : "";
   args += currentArgs.isNotEmpty
       ? "${args.isNotEmpty ? "&" : ""}current=${currentArgs.join(",")}"
       : "";


### PR DESCRIPTION
When building the url to call the open-meteo endpoint, if variables other than hourly are provided, the request cannot be performed as the & is missing in the generated URL.

The logic from the other variables is added to the hourly.