### PR TITLE
Support a wider range of dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,11 +5,11 @@ homepage: https://github.com/neursh/open-meteo-dart
 repository: https://github.com/neursh/open-meteo-dart
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ^3.0.0
 
 dependencies:
-  flat_buffers: ^23.5.26
-  http: ^1.2.2
+  flat_buffers: '>=23.5.26'
+  http: ^1.0.0
 dev_dependencies:
   lints: ^4.0.0
   test: ^1.25.8


### PR DESCRIPTION
In general, when publishing a Dart package, you want to support as many dependency versions as possible to prevent conflicts with consumers' projects. Other packages may have version limits that are incompatible with a "bleeding edge" approach, resulting in a version solving failure and turning away users.

Rationale for each change:

`sdk`: this package makes use of records (the `(0, 1)` syntax in switch cases), which were introduced in Dart `3.0.0`. We don't use any newer language features as of right now.

`flat_buffers`: the authors of this package have decided that semantic versioning doesn't make practical sense (see why [here](https://github.com/google/flatbuffers/wiki/Versioning)), so using the `^` syntax won't allow any updates beyond the year 2023. We can place an upper bound later if a user reports an issue with a newer version, but since the versioning scheme doesn't reflect breaking changes, we might assume all updates are compatible until proven otherwise.

`http`: technically, since our usage is so basic, we could probably support all the way back to some `0.*.*` version, but starting with `1.0.0` is better practice.