### PR TITLE
Perform all gh actions steps even on failure

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Previously, formatting or analysis errors would prevent us from seeing a test failure on a PR run. This ensures each step is executed even when one fails, so we can view the results of each.